### PR TITLE
related tab redirect to related main page

### DIFF
--- a/assets/components/content/contractStaff/csTabService.js
+++ b/assets/components/content/contractStaff/csTabService.js
@@ -5,6 +5,7 @@ application.service('csTabService', function($http, csTA, csDepartment, csRank, 
             return {
                 teachingActivity: {
                     title: 'Teaching Activity',
+                    link: 'application.teachingActivityCAS',
                     gridOptions: {
                         columnDefs: [{
                             name: 'Dept. Code',
@@ -44,6 +45,7 @@ application.service('csTabService', function($http, csTA, csDepartment, csRank, 
                 },
                 department: {
                     title: 'Department',
+                    link: 'application.department',
                     gridOptions: {
                         columnDefs: [{
                             name: 'Code',
@@ -64,6 +66,7 @@ application.service('csTabService', function($http, csTA, csDepartment, csRank, 
                 },
                 rank: {
                     title: 'Rank',
+                    link: 'application.rank',
                     gridOptions: {
                         columnDefs: [{
                             name: 'Name',

--- a/assets/components/content/department/dTabService.js
+++ b/assets/components/content/department/dTabService.js
@@ -5,6 +5,7 @@ application.service('dTabService', function($http, dCourse, dChair, dRegularStaf
             return {
                 course: {
                     title: 'Course',
+                    link: 'application.course',
                     gridOptions: {
                         columnDefs: [{
                             name: 'Department',
@@ -21,6 +22,7 @@ application.service('dTabService', function($http, dCourse, dChair, dRegularStaf
                 },
                 regularStaff: {
                     title: 'Regular Staff',
+                    link: 'application.regularStaff',
                     gridOptions: {
                         columnDefs: [{
                             name: 'First Name',
@@ -52,6 +54,7 @@ application.service('dTabService', function($http, dCourse, dChair, dRegularStaf
                 },
                 contractStaff: {
                     title: 'Contract Staff',
+                    link: 'application.contractStaff',
                     gridOptions: {
                         columnDefs: [{
                             name: 'First Name',

--- a/assets/components/content/faculty/fTabService.js
+++ b/assets/components/content/faculty/fTabService.js
@@ -5,6 +5,7 @@ application.service('fTabService', function($http, fDepartment) {
             return {
                 department: {
                     title: 'Department',
+                    link: 'application.department',
                     gridOptions: {
                         columnDefs: [{
                             name: 'Code',

--- a/assets/components/content/regularStaff/rsTabService.js
+++ b/assets/components/content/regularStaff/rsTabService.js
@@ -5,7 +5,7 @@ application.service('rsTabService', function($http, rsTA, rsDepartment, rsRank, 
             return {
                 teachingActivity: {
                     title: 'Teaching Activity',
-                    link: 'application.teachingRAS',
+                    link: 'application.teachingActivityRAS',
                     gridOptions: {
                         columnDefs: [{
                             name: 'Dept. Code',
@@ -67,6 +67,7 @@ application.service('rsTabService', function($http, rsTA, rsDepartment, rsRank, 
                 },
                 rank: {
                     title: 'Rank',
+                    link: 'application.rank',
                     gridOptions: {
                         columnDefs: [{
                             name: 'Name',
@@ -98,6 +99,7 @@ application.service('rsTabService', function($http, rsTA, rsDepartment, rsRank, 
                 },
                 research: {
                     title: 'Research',
+                    link: 'application.research',
                     gridOptions: {
                         columnDefs: [    {
                             name: 'Title',

--- a/assets/components/content/research/rTabService.js
+++ b/assets/components/content/research/rTabService.js
@@ -24,6 +24,7 @@ application.service('rTabService', function($http, rGrant, rStaff) {
                 },
                 staff: {
                     title: 'Staff',
+                    link: 'application.regularStaff',
                     gridOptions: {
                         columnDefs: [{
                             name: 'Dept. Code',

--- a/assets/components/navTopBar/navTopBarController.js
+++ b/assets/components/navTopBar/navTopBarController.js
@@ -15,7 +15,8 @@ application.controller('navTopBarController', function($scope, $state, $mdSidena
   $scope.update = function(searchData) {
     SearchHelper.setInput(searchData);
   };
-
+  
+ 
   /* Toggle left navigation bar */
   $scope.toggleLeft = buildToggler('left');
 

--- a/assets/components/tabset/tabset.html
+++ b/assets/components/tabset/tabset.html
@@ -1,6 +1,6 @@
 <div style="position:relative;" class="md-whiteframe-1dp" ng-cloak>
     <md-tabs id="gridTabs" md-dynamic-height md-border-bottom class="md-warn md-hue-2">
-        <md-tab ng-repeat="tab in tabs" ng-dblclick="ctrl.redirect(tab)" ng-click="selectTab(tab)"  label="{{tab.title}}">
+        <md-tab ng-repeat="tab in tabs" ng-click="selectTab(tab)" label="{{tab.title}}">
             <div ui-grid="tab.gridOptions" ui-grid-selection ui-grid-resize-columns class="grid"></div>
         </md-tab>
     </md-tabs>
@@ -20,6 +20,10 @@
             <md-button class="md-fab md-raised md-mini" ng-click="editTabRow(); ctrl.toggle()" aria-label="Edit">
                 <md-tooltip md-direction="top" md-visible="tooltipVisible">Edit</md-tooltip>
                 <md-icon md-font-set="material-icons" ng-style="{color: '#333'}">create</md-icon>
+            </md-button>
+            <md-button ng-show="ctrl.pageExist(tab)" class="md-fab md-raised md-mini" ng-click="ctrl.redirect(tab); ctrl.toggle()" aria-label="Edit">
+                <md-tooltip md-direction="top" md-visible="tooltipVisible">GoTo Page</md-tooltip>
+                <md-icon md-font-set="material-icons" ng-style="{color: '#333'}">open_in_browser</md-icon>
             </md-button>
         </md-fab-actions>
     </md-fab-speed-dial>

--- a/assets/components/tabset/tabsetController.js
+++ b/assets/components/tabset/tabsetController.js
@@ -1,14 +1,22 @@
-application.controller('tabsetController', function(navRightBarService, CurrentUser) {
-    
+application.controller('tabsetController', function(navRightBarService, CurrentUser, $state) {
+
     var self = this;
     var userRole;
-    
+
     self.toggle = function() {
         navRightBarService.toggle();
     };
     
+    self.redirect = function(tab) {
+        $state.go(tab.link);
+    };
+    
     self.isReader = function() {
         if (!userRole) userRole = CurrentUser.getRole();
-        return (userRole === "reader");    
+        return (userRole === "reader");
+    };
+    
+    self.pageExist = function(tab) {
+        return (tab.link) ? true : false;
     };
 });


### PR DESCRIPTION
- add new button in speed dial for tabset for their respective pages that exists
- button redirects to related main page

close #241

maybe pick a better icon

Usage:

add `link` property in gridOption of tabServices for pages that exists
